### PR TITLE
Remove FileAPI from frontend

### DIFF
--- a/app/components/FileUpload.js
+++ b/app/components/FileUpload.js
@@ -3,36 +3,31 @@ import React from 'react'
 class FileUpload extends React.Component {
 
     constructor() {
-        super()
-        this.fileInput = React.createRef()
-        this.sendFile = this.sendFile.bind(this)
+        super();
+        this.fileInput = React.createRef();
+        this.sendFile = this.sendFile.bind(this);
     }
 
     sendFile(event) {
         event.preventDefault();
 
-        let [ file ] = this.fileInput.files
-        const reader = new FileReader()
+        const files = this.fileInput.files;
+        const formData = new FormData();
 
-        // register callback for when the file is completely read
-        reader.onload = event => {
-            fetch('http://localhost:8080/upload', {
-                method: 'POST',
-                headers: {
-                    "Content-Type": "application/json"
-                },
-                body: JSON.stringify({ 'text': event.target.result })
-            }).catch(error => alert('There has been a problem with your fetch operation: ', error.message))
+        for (var i = 0; i < files.length; i++) {
+            formData.append('file', files[i]);
         }
 
-        // read the file
-        reader.readAsText(file)
+        fetch('http://localhost:8080/upload', {
+            method: 'POST',
+            body: formData
+        }).catch(error => alert('There has been a problem with your fetch operation: ', error.message));
     }
 
     render() {
         return (
             <form onSubmit={this.sendFile}>
-                File: <input ref={(input) => this.fileInput = input} type="file" /><br/>
+                File: <input ref={(input) => this.fileInput = input} type="file" multiple/><br/>
                 <input type="submit" value="Submit"/>
             </form>
         )

--- a/src/main/scala/io/beagle/directive/FileUpload.scala
+++ b/src/main/scala/io/beagle/directive/FileUpload.scala
@@ -64,12 +64,10 @@ class FileUploadController(fileUploadActor: ActorRef)(implicit executionContext:
   implicit val responseFormat = jsonFormat1(FileUploadResponse)
 
   def upload = path("upload") {
-    post {
-      entity(as[FileUploadRequest]) { request =>
-        onComplete(( fileUploadActor ? request ).mapTo[FileUploadResponse]) {
-          case Success(value) => complete("success")
-          case Failure(throwable) => failWith(throwable)
-        }
+    formField('file.*) { request =>
+      onComplete(( fileUploadActor ? FileUploadRequest(request.mkString("\n")) ).mapTo[FileUploadResponse]) {
+        case Success(value) => complete(value)
+        case Failure(throwable) => failWith(throwable)
       }
     }
   }


### PR DESCRIPTION
Why:

* Not every browser supports it.
* It might be a little overkill rightnow.
* Fixes #16

How:

* The files are now uploaded as form-data.